### PR TITLE
Added GOV.UK OL Support page and active footer link

### DIFF
--- a/app/views/layouts/_base-one-login.html
+++ b/app/views/layouts/_base-one-login.html
@@ -1,7 +1,7 @@
 {% extends "layouts/main.html" %}
 
 {% block pageTitle %}
-    {{title}} – GOV.UK 
+    {{title}} – GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
@@ -47,9 +47,12 @@
                 text: "Privacy notice"
             },
             {
-                href: "",
-                text: "Support (opens in new tab)"
-            }
+                text: "Support (opens in new tab)",
+                href: "/ur-r4/gds/contact-gov-uk-one-login",
+                attributes: {
+                target: "_blank"
+                }
+              }
         ],
         visuallyHiddenTitle: "Footer links"
     }

--- a/app/views/ur-r4/gds/contact-gov-uk-one-login.html
+++ b/app/views/ur-r4/gds/contact-gov-uk-one-login.html
@@ -1,0 +1,109 @@
+{% extends "layouts/_base-one-login.html" %}
+{% set phaseBanner = 'true' %}
+{% set backLink = 'false' %}
+
+{% set title =  "Contact GOV.UK One Login" %}
+
+{% block content %}
+
+      <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+        <main class="govuk-main-wrapper " id="main-content" role="main" >
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds ">
+
+<h1 class="govuk-heading-xl">{{title}}</h1>
+
+    <section>
+
+      <h2 class="govuk-heading-l">Before you contact us</h2>
+
+        <p class="govuk-body">Read our guidance if you're having a problem with:</p>
+
+
+      <ul class="govuk-list govuk-list--bullet">
+
+          <li><a class="govuk-link" href="https://www.gov.uk/guidance/using-the-govuk-id-check-app">Using the GOV.UK ID Check app</a></li>
+
+          <li><a class="govuk-link" href="https://www.gov.uk/guidance/proving-your-identity-with-govuk-one-login-by-answering-security-questions">Proving your identity with GOV.UK One Login by answering security questions</a></li>
+
+          <li><a class="govuk-link" href="https://www.gov.uk/guidance/changing-the-sign-in-details-for-your-govuk-one-login">Changing the sign in details for your GOV.UK One Login</a></li>
+
+          <li><a class="govuk-link" href="https://www.gov.uk/guidance/getting-a-security-code-for-govuk-one-login">Getting a security code for GOV.UK One Login</a></li>
+
+          <li><a class="govuk-link" href="https://www.gov.uk/guidance/deleting-your-govuk-one-login">Deleting your GOV.UK One Login</a></li>
+
+      </ul>
+
+    </section>
+    <hr class="govuk-section-break govuk-section-break--m">
+
+  <section>
+    <h2 class="govuk-heading-l">Ways to contact us</h2>
+
+  <section>
+    <h3 class="govuk-heading-m">Phone</h3>
+
+    <p class="govuk-body">When you contact us by phone, you’ll be asked for a reference code.</p>
+
+    <p class="govuk-body">This code helps us to see where you may be having a problem.</p>
+
+
+  <p class="govuk-body contact-reference">
+    Your reference code is:
+    <strong class="contact-reference__code">564907</strong>
+  </p>
+
+    <div class="govuk-inset-text">
+
+      <p class="govuk-body">From the UK:<br><strong>0300 373 9020</strong></p>
+
+      <p class="govuk-body">Outside the UK:<br><strong>+44 208 629 0008</strong></p>
+
+</div>
+
+      <p class="govuk-body">Opening times:<br>Monday to Friday, 8am to 8pm <br>Weekends and public holidays, 9am to 5.30pm</p>
+
+      <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/call-charges">Find out about call charges</a></p>
+
+  </section>
+
+  <section>
+
+      <h3 class="govuk-heading-m">Email</h3>
+
+      <p class="govuk-body"><a class="govuk-link" href="/track-and-redirect">Fill in the contact form</a> to ask for help.</p>
+
+      <p class="govuk-body">We’ll reply by email within 2 days.</p>
+
+      <p class="govuk-body">Opening times:<br>Monday to Friday, 8am to 8pm <br>Weekends and public holidays, 9am to 5.30pm</p>
+
+  </section>
+
+  </section>
+
+
+    <hr class="govuk-section-break govuk-section-break--m">
+    <section>
+
+      <h2 class="govuk-heading-l">How we use your information</h2>
+
+        <p class="govuk-body">To find out what information we store when you contact us and how we use it, see the <a href="https://signin.account.gov.uk/privacy-notice" class="govuk-link">GOV.UK One Login privacy notice.</a></p>
+
+    </section>
+
+    </div>
+</div>
+
+        </main>
+
+    <script type="text/javascript" src="/public/scripts/application.js" nonce='4fec198fa0b8ce591b5e99712384f6c0'></script>
+    <script type="text/javascript" src="/public/scripts/all.js" nonce='4fec198fa0b8ce591b5e99712384f6c0'></script>
+    <script type="text/javascript" nonce='4fec198fa0b8ce591b5e99712384f6c0'>
+        window
+            .GOVSignIn
+            .appInit("GTM-TT5HDKV", "account.gov.uk")
+    </script>
+
+{% endblock %}


### PR DESCRIPTION
Added the GOV.UK OL Contact and Support page. Also made the link to the support page in the footer active to open this page in a new tab.