### PR TITLE
Update cookies page

### DIFF
--- a/app/views/footer/cookies.html
+++ b/app/views/footer/cookies.html
@@ -157,7 +157,7 @@
                 fieldset: {
                     legend: {
                     text: "Do you want to accept cookies that measure your website use?",
-                    isPageHeading: true,
+                    isPageHeading: false,
                     classes: "govuk-fieldset__legend--m"
                     }
                 },


### PR DESCRIPTION
- made changes to the radio button question in the cookies page
- page heading was set to true, now it has been changed to false since we already has an H1 in the page