### PR TITLE
Implemented One Login friction page

### DIFF
--- a/app/views/changelog.html
+++ b/app/views/changelog.html
@@ -30,7 +30,11 @@
       <li>
         Updated Maternity Allowance service page that follows authentication.
 </li>
+<li>
+  Included a new template page from GOV.UK One Login. It's a friction page that only appears when a user clicks the browser back button during the identity verification journey.  <a class="govuk-link--no-visited-state" href="https://prototype-dwp-govuk-ol-87876067d492.herokuapp.com/dev-ready/pyi-attempt-recovery">This page here.</a> 
+</li>
     </ul>
+    
 
     <h2 class="govuk-heading-m">
       March 2025

--- a/app/views/dev-ready/pyi-attempt-recovery.html
+++ b/app/views/dev-ready/pyi-attempt-recovery.html
@@ -1,0 +1,47 @@
+{% extends "layouts/_base-one-login.html" %}
+{% set phaseBanner = 'true' %}
+{% set languageToggle = 'true' %}
+
+{% set title =  "Sorry, you cannot go back" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <form class="form" action="/pyi-attempt-recovery" method="post">
+
+
+      
+                
+            <h1 class="govuk-heading-l" id="header" data-page="pyiAttemptRecovery">Sorry, you cannot go back</h1>
+            <p class="govuk-body">You cannot go back if you’ve already started entering information to prove your identity online.</p>
+            <h2 class="govuk-heading-m">What you can do</h2>
+            <p class="govuk-body">Continue proving your identity online.</p>
+          
+  
+            
+          
+        
+  
+  
+  
+  
+  
+
+  
+  
+  
+  <button name="submitButton" class="govuk-button" data-module="govuk-button">
+  Continue
+  </button>
+  <p class="govuk-body">
+    <a target="_blank" rel="noopener noreferrer" href="https://home.account.gov.uk/contact-gov-uk-one-login?fromUrl=https%3A%2F%2Fidentity.account.gov.uk%2Fipv%2Fpage%2Fpyi-attempt-recovery" class="govuk-link">
+        Contact the GOV.UK One Login team (opens in a new tab)
+    </a>
+</p>
+
+    </div>
+</div>
+
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -87,6 +87,10 @@
           <li>
             <a class="govuk-link" href="/dev-ready/sign-out">Sign out example (GOV.UK One Login)</a>
           </li>
+          <li>
+            <a class="govuk-link" href="/dev-ready/pyi-attempt-recovery">Sorry, you cannot go back (GOV.UK One Login)</a>
+          </li>
+          
         </ul>
       </p>
   


### PR DESCRIPTION
Included a new template page from GOV.UK One Login. It's a friction page that only appears when a user clicks the browser back button during the identity verification journey.